### PR TITLE
Change service ports to correct outside container port

### DIFF
--- a/infra/kafka/2-broker-cfg.yaml
+++ b/infra/kafka/2-broker-cfg.yaml
@@ -27,7 +27,7 @@ data:
       fi
 
       OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
-      OUTSIDE_PORT=$((32400 + ${KAFKA_BROKER_ID}))
+      OUTSIDE_PORT=$((30092 + ${KAFKA_BROKER_ID}))
       SEDS+=("s|#init#advertised.listeners=PLAINTEXT://#init#|advertised.listeners=PLAINTEXT://broker.jalapeno:9092,OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
       ANNOTATIONS="$ANNOTATIONS kafka-listener-outside-host=$OUTSIDE_HOST kafka-listener-outside-port=$OUTSIDE_PORT"
 
@@ -255,4 +255,3 @@ data:
     # Change to DEBUG to enable audit log for the authorizer
     log4j.logger.kafka.authorizer.logger=WARN, authorizerAppender
     log4j.additivity.kafka.authorizer.logger=false
-

--- a/infra/kafka/3-kafka.yaml
+++ b/infra/kafka/3-kafka.yaml
@@ -18,10 +18,10 @@ metadata:
     namespace: jalapeno
 spec:
     ports:
-      - name: 9092-tcp
-        port: 9092
+      - name: 9094-tcp
+        port: 9094
         nodePort: 30092
-        targetPort: 9092
+        targetPort: 9094
     type: NodePort
     selector:
       app: kafka


### PR DESCRIPTION
Closes #36 

The outside listeners in the `broker.cfg` have to be bound to the correct service port `30092` from the kafka NodePort service to access the kafka from outside the cluster correctly, 

The kafka NodePort service must be bound to the outside container port of kafka (9094) instead of the inside container port (9092).