### PR TITLE
Docs: Add Ubuntu 22.04 to pre-reqs & fix duplicate sections in processors

### DIFF
--- a/docs/about/processors.md
+++ b/docs/about/processors.md
@@ -14,22 +14,6 @@ For example, the Topology processor creates the LSNode collection and the LSLink
 
 The configuration for topology deployment is in "topology_dp.yaml" in the topology directory.
 
-# Jalapeno Data Processors
-
-Jalapeno's Data Processors are responsible for organizing, parsing, and analysing network topology and performance data.
-
-Any Jalapeno Infrastructure component with data is considered a source for a Processor.
-
-## Topology Processor
-
-BGP speakers send BMP data feeds to GoBMP, which then passes the data to Kafka.  The Topology Processor subscribes to Kafka's BMP topics in order to create topology representations in ArangoDB.
-
-Collections created using this service are considered base-collections. These base-collections have no inference of relationships between network elements, or of any metrics - they are organized collections of individual [GoBMP](https://github.com/sbezverk/gobmp) messages.
-
-For example, the Topology processor creates the LSNode collection and the LSLink collection directly from GoBMP BGP-LS message data.
-
-The configuration for topology deployment is in "topology_dp.yaml" in the topology directory.
-
 ## Other Processors
 
 Currently the project is bundled with a limited set of processors. However, other processors can be found in [this repository](https://github.com/orgs/jalapeno/repositories) which may offer additional functionality to Jalapeno.

--- a/docs/install/prerequisites.md
+++ b/docs/install/prerequisites.md
@@ -4,6 +4,7 @@ Jalapeno has been primarily developed, tested, and operated on:
 
 - Ubuntu 18.04
 - Ubuntu 20.04
+- Ubuntu 22.04
 
 With the following Kubernetes environments (Bare-metal, VM, or Cloud):
 


### PR DESCRIPTION
Two quick updates to the new docs site:

- Add Ubuntu 22.04 to `/docs/install/prerequisites.md`
- Remove duplicate sections in `docs/about/processors.md`